### PR TITLE
Reduce Docker Image Size

### DIFF
--- a/default.Dockerfile
+++ b/default.Dockerfile
@@ -5,6 +5,10 @@ WORKDIR /opt/spec2vec_mlops
 COPY . /opt/spec2vec_mlops
 RUN cat requirements/environment.frozen.yaml | sed 's/spec2vec_mlops/base/g' > environment-docker.yml
 
-RUN /opt/conda/bin/conda env update --file environment-docker.yml
+RUN /opt/conda/bin/conda env update --file environment-docker.yml \
+    && /opt/conda/bin/conda clean -afy \
+    && find /opt/conda/ -follow -type f -name '*.a' -delete \
+    && find /opt/conda/ -follow -type f -name '*.pyc' -delete \
+    && find /opt/conda/ -follow -type f -name '*.js.map' -delete
 
 RUN pip install -e /opt/spec2vec_mlops


### PR DESCRIPTION
after removing conda cache in Dockerfile, compressed image size has reduced from 1000 MBs to 500 MB.

--- don't change below this line ---
MLOPS-184 #time 6m