### PR TITLE
remove spectra that do not have peaks

### DIFF
--- a/spec2vec_mlops/tasks/clean_data.py
+++ b/spec2vec_mlops/tasks/clean_data.py
@@ -16,6 +16,7 @@ def clean_data_task(spectra_data_chunks: List[Dict]) -> List[str]:
     cleaned_data = [
         data_cleaner.clean_data(spectra_data) for spectra_data in spectra_data_chunks
     ]
+    cleaned_data = [spectrum for spectrum in cleaned_data if spectrum]
     storer = SpectrumStorer("spectrum_info")
     spectrum_ids = storer.store(cleaned_data)
     ids_storer = SpectrumIDStorer("spectrum_ids_info")


### PR DESCRIPTION
A small change to remove spectra with `None` from a list of spectra. 

This fixed the problem that occurred when cleaning a spectrum that don't have peaks_json