### PR TITLE
[on hold] use json.dumps instead of pickle.dumps when possible

### DIFF
--- a/spec2vec_mlops/entities/embedding.py
+++ b/spec2vec_mlops/entities/embedding.py
@@ -1,3 +1,5 @@
+import json
+
 import numpy as np
 
 
@@ -6,3 +8,23 @@ class Embedding:
         self.vector = vector
         self.spectrum_id = spectrum_id
         self.n_decimals = n_decimals
+
+    @classmethod
+    def from_dict(cls, dct: dict):
+        return cls(
+            vector=np.array(dct["vector"]),
+            spectrum_id=dct["spectrum_id"],
+            n_decimals=dct["n_decimals"],
+        )
+
+
+class EmbeddingJSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, Embedding):
+            embedding_dict = {
+                "spectrum_id": o.spectrum_id,
+                "n_decimals": o.n_decimals,
+                "vector": o.vector.tolist(),
+            }
+            return embedding_dict
+        return json.JSONEncoder.default(self, o)

--- a/spec2vec_mlops/test/gateways/test_redis_gateway.py
+++ b/spec2vec_mlops/test/gateways/test_redis_gateway.py
@@ -1,14 +1,16 @@
+import json
 import os
 import pickle
 from typing import Iterable
 
 import pytest
+from matchms.exporting.save_as_json import SpectrumJSONEncoder
 from matchms.Spectrum import Spectrum
 from pytest_redis import factories
 from spec2vec.SpectrumDocument import SpectrumDocument
 
 from spec2vec_mlops import config
-from spec2vec_mlops.entities.embedding import Embedding
+from spec2vec_mlops.entities.embedding import Embedding, EmbeddingJSONEncoder
 from spec2vec_mlops.entities.spectrum_document import SpectrumDocumentData
 from spec2vec_mlops.gateways.redis_gateway import RedisDataGateway
 
@@ -35,7 +37,9 @@ def spectra_stored(redis_db, cleaned_data):
             {spectrum.metadata["spectrum_id"]: spectrum.metadata["precursor_mz"]},
         )
         pipe.hset(
-            SPECTRUM_HASHES, spectrum.metadata["spectrum_id"], pickle.dumps(spectrum)
+            SPECTRUM_HASHES,
+            spectrum.metadata["spectrum_id"],
+            json.dumps(spectrum, cls=SpectrumJSONEncoder),
         )
     pipe.execute()
 
@@ -60,7 +64,7 @@ def embeddings_stored(redis_db, embeddings):
         pipe.hset(
             f"{EMBEDDING_HASHES}_{run_id}",
             embedding.spectrum_id,
-            pickle.dumps(embedding),
+            json.dumps(embedding, cls=EmbeddingJSONEncoder),
         )
     pipe.execute()
 

--- a/spec2vec_mlops/test/helper_classes/test_spec2vec_model.py
+++ b/spec2vec_mlops/test/helper_classes/test_spec2vec_model.py
@@ -10,6 +10,7 @@ from seldon_core.metrics import SeldonMetrics
 from seldon_core.wrapper import get_rest_microservice
 
 from spec2vec_mlops import config
+from spec2vec_mlops.entities.embedding import EmbeddingJSONEncoder
 from spec2vec_mlops.helper_classes.embedding_maker import EmbeddingMaker
 from spec2vec_mlops.helper_classes.exception import (
     MandatoryKeyMissingException,
@@ -127,7 +128,7 @@ def test_get_reference_embeddings(model, embeddings, redis_db):
     for embedding in embeddings:
         pipe.hmset(
             f"{EMBEDDING_HASHES}_{run_id}",
-            {embedding.spectrum_id: pickle.dumps(embedding)},
+            {embedding.spectrum_id: json.dumps(embedding, cls=EmbeddingJSONEncoder)},
         )
     pipe.execute()
 
@@ -147,7 +148,7 @@ def test_predict_from_saved_model(
         pipe.hset(
             f"{EMBEDDING_HASHES}_{saved_model_run_id}",
             embedding.spectrum_id,
-            pickle.dumps(embedding),
+            json.dumps(embedding, cls=EmbeddingJSONEncoder),
         )
     pipe.execute()
 


### PR DESCRIPTION
S3 seems much slower than Redis. Let's wait until we speed up the training to merge this branch. 