### PR TITLE
mark job pod safe-to-evict = False

### DIFF
--- a/spec2vec_mlops/job_spec.yaml
+++ b/spec2vec_mlops/job_spec.yaml
@@ -1,0 +1,10 @@
+apiVersion: batch/v1
+kind: Job
+spec:
+  template:
+    metadata:
+      annotations:
+        "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
+    spec:
+      containers:
+      - name: flow


### PR DESCRIPTION
This is done so that autoscaling works when running a big job

See this: https://github.com/PrefectHQ/prefect/issues/3058